### PR TITLE
feat: Add create expense page and component

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import {IndexComponent} from './pages/index/index.component';
 import { ExpenseList } from './pages/expense-list/expense-list'; // Import ExpenseList
+import { CreateExpensePage } from './pages/create-expense/create-expense.page';
 
 const routes: Routes = [
   {
@@ -11,6 +12,10 @@ const routes: Routes = [
   {
     path: 'expenses', // New route
     component: ExpenseList
+  },
+  {
+    path: 'expenses/create',
+    component: CreateExpensePage
   }
 ];
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule, provideClientHydration, withEventReplay } from '@angular/platform-browser';
-import { FormsModule } from '@angular/forms'; // Import FormsModule
+import { FormsModule, ReactiveFormsModule } from '@angular/forms'; // Import FormsModule and ReactiveFormsModule
 
 import { AppRoutingModule } from './app-routing.module';
 import {BaseComponent} from './components/base/base.component';
@@ -12,6 +12,8 @@ import {ToastComponent} from './components/toast/toast.component';
 import {ToastStore} from './stores/toast.store';
 import { ExpenseList } from './pages/expense-list/expense-list';
 import {ExpenseRepository} from './stores/expense-repository';
+import { CreateExpenseComponent } from './components/create-expense/create-expense.component';
+import { CreateExpensePage } from './pages/create-expense/create-expense.page';
 
 @NgModule({
   declarations: [
@@ -22,14 +24,18 @@ import {ExpenseRepository} from './stores/expense-repository';
 
     // Pages
     IndexComponent,
-     ExpenseList,
+    ExpenseList,
+    CreateExpensePage,
 
+    // Components
+    CreateExpenseComponent,
 
   ],
   imports: [
     BrowserModule,
     AppRoutingModule,
-    FormsModule // Add FormsModule here
+    FormsModule, // Add FormsModule here
+    ReactiveFormsModule
   ],
   providers: [
     provideClientHydration(withEventReplay()),

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule, provideClientHydration, withEventReplay } from '@angular/platform-browser';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms'; // Import FormsModule and ReactiveFormsModule
+import { CommonModule } from '@angular/common'; // Import CommonModule
 
 import { AppRoutingModule } from './app-routing.module';
 import {BaseComponent} from './components/base/base.component';
@@ -35,7 +36,8 @@ import { CreateExpensePage } from './pages/create-expense/create-expense.page';
     BrowserModule,
     AppRoutingModule,
     FormsModule, // Add FormsModule here
-    ReactiveFormsModule
+    ReactiveFormsModule,
+    CommonModule // Add CommonModule here
   ],
   providers: [
     provideClientHydration(withEventReplay()),

--- a/src/app/components/create-expense/create-expense.component.html
+++ b/src/app/components/create-expense/create-expense.component.html
@@ -1,0 +1,53 @@
+<form [formGroup]="expenseForm" (ngSubmit)="onSubmit()">
+  <div>
+    <label for="transactionDate">Transaction Date:</label>
+    <input type="date" id="transactionDate" formControlName="transactionDate" aria-label="Transaction Date">
+    <div *ngIf="expenseForm.controls['transactionDate'].invalid && (expenseForm.controls['transactionDate'].dirty || expenseForm.controls['transactionDate'].touched)">
+      <small *ngIf="expenseForm.controls['transactionDate'].errors?.['required']">Transaction date is required.</small>
+    </div>
+  </div>
+
+  <div>
+    <label for="amount">Amount:</label>
+    <input type="number" id="amount" formControlName="amount" aria-label="Amount">
+    <div *ngIf="expenseForm.controls['amount'].invalid && (expenseForm.controls['amount'].dirty || expenseForm.controls['amount'].touched)">
+      <small *ngIf="expenseForm.controls['amount'].errors?.['required']">Amount is required.</small>
+      <small *ngIf="expenseForm.controls['amount'].errors?.['pattern']">Amount must be a positive number.</small>
+      <small *ngIf="expenseForm.controls['amount'].errors?.['min']">Amount must be greater than 0.</small>
+    </div>
+  </div>
+
+  <div>
+    <label for="currency">Currency:</label>
+    <input type="text" id="currency" formControlName="currency" aria-label="Currency">
+    <div *ngIf="expenseForm.controls['currency'].invalid && (expenseForm.controls['currency'].dirty || expenseForm.controls['currency'].touched)">
+      <small *ngIf="expenseForm.controls['currency'].errors?.['required']">Currency is required.</small>
+      <small *ngIf="expenseForm.controls['currency'].errors?.['minlength'] || expenseForm.controls['currency'].errors?.['maxlength']">Currency must be 3 characters.</small>
+    </div>
+  </div>
+
+  <div>
+    <label for="location">Location:</label>
+    <input type="text" id="location" formControlName="location" aria-label="Location">
+  </div>
+
+  <div>
+    <label for="description">Description:</label>
+    <textarea id="description" formControlName="description" aria-label="Description"></textarea>
+    <div *ngIf="expenseForm.controls['description'].invalid && (expenseForm.controls['description'].dirty || expenseForm.controls['description'].touched)">
+      <small *ngIf="expenseForm.controls['description'].errors?.['required']">Description is required.</small>
+    </div>
+  </div>
+
+  <div>
+    <label for="categories">Categories:</label>
+    <input type="text" id="categories" formControlName="categories" placeholder="comma-separated" aria-label="Categories">
+  </div>
+
+  <div>
+    <label for="labels">Labels:</label>
+    <input type="text" id="labels" formControlName="labels" placeholder="comma-separated" aria-label="Labels">
+  </div>
+
+  <button type="submit" [disabled]="expenseForm.invalid">Create Expense</button>
+</form>

--- a/src/app/components/create-expense/create-expense.component.ts
+++ b/src/app/components/create-expense/create-expense.component.ts
@@ -3,6 +3,7 @@ import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angula
 import { ExpenseRepository } from '../../stores/expense-repository';
 import { ToastStore } from '../../stores/toast.store';
 import { Expense } from '../../interfaces/expense.interface';
+import { ToastMessageInterface } from '../../interfaces/toast-message.interface';
 
 @Component({
   selector: 'app-create-expense',
@@ -50,16 +51,25 @@ export class CreateExpenseComponent implements OnInit {
       labels: labels,
     };
 
-    this.expenseRepository.create(expenseData).subscribe({
-      next: () => {
-        this.toastStore.showToast('Expense created successfully!');
+    this.expenseRepository.create(expenseData)
+      .then((createdExpense) => { // 'createdExpense' is the resolved value from the Promise
+        // Success logic
+        this.toastStore.publish({ message: 'Expense created successfully!' });
         this.expenseForm.reset();
-      },
-      error: (error: any) => {
-        this.toastStore.showToast('Error creating expense.', 'error');
+        // Optionally, re-enable the submit button or clear markings here if needed
+        Object.keys(this.expenseForm.controls).forEach(key => {
+          this.expenseForm.get(key)?.clearValidators(); // Or reset specific properties
+          this.expenseForm.get(key)?.updateValueAndValidity();
+          this.expenseForm.get(key)?.setErrors(null);
+          this.expenseForm.get(key)?.markAsPristine();
+          this.expenseForm.get(key)?.markAsUntouched();
+        });
+      })
+      .catch((error: any) => {
+        // Error logic
+        this.toastStore.publish({ message: 'Error creating expense.' });
         console.error('Error creating expense:', error);
-      }
-    });
+      });
   }
 
   private markAllAsTouched(): void {

--- a/src/app/components/create-expense/create-expense.component.ts
+++ b/src/app/components/create-expense/create-expense.component.ts
@@ -8,6 +8,7 @@ import { Expense } from '../../../interfaces/expense.interface';
   selector: 'app-create-expense',
   templateUrl: './create-expense.component.html',
   // styleUrls: ['./create-expense.component.css'] // Assuming you might add styles later
+  standalone: false,
 })
 export class CreateExpenseComponent implements OnInit {
   expenseForm!: FormGroup;
@@ -55,7 +56,7 @@ export class CreateExpenseComponent implements OnInit {
         this.toastStore.showToast('Expense created successfully!');
         this.expenseForm.reset();
       },
-      error: (error) => {
+      error: (error: any) => {
         this.toastStore.showToast('Error creating expense.', 'error');
         console.error('Error creating expense:', error);
       }

--- a/src/app/components/create-expense/create-expense.component.ts
+++ b/src/app/components/create-expense/create-expense.component.ts
@@ -1,0 +1,70 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ExpenseRepository } from '../../../stores/expense-repository';
+import { ToastStore } from '../../../stores/toast.store';
+import { Expense } from '../../../interfaces/expense.interface';
+
+@Component({
+  selector: 'app-create-expense',
+  templateUrl: './create-expense.component.html',
+  // styleUrls: ['./create-expense.component.css'] // Assuming you might add styles later
+})
+export class CreateExpenseComponent implements OnInit {
+  expenseForm!: FormGroup;
+
+  constructor(
+    private fb: FormBuilder,
+    private expenseRepository: ExpenseRepository,
+    private toastStore: ToastStore
+  ) {}
+
+  ngOnInit(): void {
+    this.expenseForm = this.fb.group({
+      transactionDate: ['', [Validators.required]],
+      amount: ['', [Validators.required, Validators.pattern(/^[0-9]*\.?[0-9]+$/), Validators.min(0.01)]],
+      currency: ['', [Validators.required, Validators.minLength(3), Validators.maxLength(3)]],
+      location: [''],
+      description: ['', [Validators.required]],
+      categories: [''],
+      labels: ['']
+    });
+  }
+
+  onSubmit(): void {
+    if (this.expenseForm.invalid) {
+      this.markAllAsTouched();
+      return;
+    }
+
+    const formValues = this.expenseForm.value;
+    const categories = formValues.categories ? formValues.categories.split(',').map((s: string) => s.trim()) : [];
+    const labels = formValues.labels ? formValues.labels.split(',').map((s: string) => s.trim()) : [];
+
+    const expenseData: Omit<Expense, 'id' | 'createdAt'> = {
+      transactionDate: new Date(formValues.transactionDate),
+      amount: parseFloat(formValues.amount),
+      currency: formValues.currency.toUpperCase(),
+      location: formValues.location,
+      description: formValues.description,
+      categories: categories,
+      labels: labels,
+    };
+
+    this.expenseRepository.create(expenseData).subscribe({
+      next: () => {
+        this.toastStore.showToast('Expense created successfully!');
+        this.expenseForm.reset();
+      },
+      error: (error) => {
+        this.toastStore.showToast('Error creating expense.', 'error');
+        console.error('Error creating expense:', error);
+      }
+    });
+  }
+
+  private markAllAsTouched(): void {
+    Object.values(this.expenseForm.controls).forEach(control => {
+      control.markAsTouched();
+    });
+  }
+}

--- a/src/app/components/create-expense/create-expense.component.ts
+++ b/src/app/components/create-expense/create-expense.component.ts
@@ -1,13 +1,12 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
-import { ExpenseRepository } from '../../../stores/expense-repository';
-import { ToastStore } from '../../../stores/toast.store';
-import { Expense } from '../../../interfaces/expense.interface';
+import { ExpenseRepository } from '../../stores/expense-repository';
+import { ToastStore } from '../../stores/toast.store';
+import { Expense } from '../../interfaces/expense.interface';
 
 @Component({
   selector: 'app-create-expense',
   templateUrl: './create-expense.component.html',
-  // styleUrls: ['./create-expense.component.css'] // Assuming you might add styles later
   standalone: false,
 })
 export class CreateExpenseComponent implements OnInit {

--- a/src/app/pages/create-expense/create-expense.page.html
+++ b/src/app/pages/create-expense/create-expense.page.html
@@ -1,0 +1,2 @@
+<h1>Create New Expense</h1>
+<app-create-expense></app-create-expense>

--- a/src/app/pages/create-expense/create-expense.page.ts
+++ b/src/app/pages/create-expense/create-expense.page.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-create-expense-page',
+  templateUrl: './create-expense.page.html',
+})
+export class CreateExpensePage {}

--- a/src/app/pages/create-expense/create-expense.page.ts
+++ b/src/app/pages/create-expense/create-expense.page.ts
@@ -3,5 +3,6 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'app-create-expense-page',
   templateUrl: './create-expense.page.html',
+  standalone: false,
 })
 export class CreateExpensePage {}

--- a/src/app/stores/expense-repository.ts
+++ b/src/app/stores/expense-repository.ts
@@ -1,8 +1,12 @@
+import { Injectable } from '@angular/core';
 import { Expense } from '../interfaces/expense.interface';
 
 const DB_NAME = 'ExpenseDB';
 const STORE_NAME = 'expenses';
 
+@Injectable({
+  providedIn: 'root',
+})
 export class ExpenseRepository {
   private dbPromise: Promise<IDBDatabase>;
 


### PR DESCRIPTION
Adds a new page at /expenses/create that allows you to create new expenses.

The new `CreateExpenseComponent` provides a form to input expense details, including transaction date, amount, currency, location, description, categories, and labels. Input validation is included for required fields, amount format, and currency code length.

The component uses `ExpenseRepository` to save the expense data to IndexedDB and `ToastStore` to display success or error messages.

The `CreateExpensePage` simply hosts the `CreateExpenseComponent`.

Relevant modules (`AppRoutingModule`, `AppModule`) have been updated to include the new page, component, and necessary dependencies like `ReactiveFormsModule`.