### PR TITLE
Refactor(DatepickerRange): Remove input and display date range in button

### DIFF
--- a/src/app/components/datepicker-range/datepicker-range.component.html
+++ b/src/app/components/datepicker-range/datepicker-range.component.html
@@ -1,8 +1,8 @@
 <form class="row row-cols-sm-auto">
-  <button class="btn btn-outline-secondary" (click)="datepicker.toggle()" type="button">{{ formattedRange }}</button>
-  <div class="dp-hidden position-absolute">
-    <div class="input-group">
-      <input
+  <div class="col-12">
+    <div class="dp-hidden position-absolute">
+      <div class="input-group">
+        <input
           name="datepicker"
           class="form-control"
           ngbDatepicker
@@ -29,6 +29,6 @@
         </ng-template>
       </div>
     </div>
-    </div>
+    <button class="btn btn-outline-secondary bi bi-calendar3" (click)="datepicker.toggle()" type="button">{{formattedRange}}</button>
   </div>
 </form>

--- a/src/app/components/datepicker-range/datepicker-range.component.html
+++ b/src/app/components/datepicker-range/datepicker-range.component.html
@@ -29,6 +29,6 @@
         </ng-template>
       </div>
     </div>
-    <button class="btn btn-outline-secondary bi bi-calendar3" (click)="datepicker.toggle()" type="button">{{formattedRange}}</button>
+    <button id="js-daterangepicker-predefined" class="btn btn-light btn-sm dropdown-toggle" (click)="datepicker.toggle()" type="button"> <i class="bi-calendar-week"></i>{{formattedRange}}</button>
   </div>
 </form>

--- a/src/app/components/datepicker-range/datepicker-range.component.html
+++ b/src/app/components/datepicker-range/datepicker-range.component.html
@@ -1,10 +1,9 @@
-<form class="row row-cols-sm-auto">
-  <div class="col-12">
+<form>
     <div class="dp-hidden position-absolute">
       <div class="input-group">
         <input
           name="datepicker"
-          class="form-control"
+          class="dp-hidden"
           ngbDatepicker
           #datepicker="ngbDatepicker"
           [autoClose]="'outside'"
@@ -29,6 +28,8 @@
         </ng-template>
       </div>
     </div>
-    <button id="js-daterangepicker-predefined" class="btn btn-light btn-sm dropdown-toggle" (click)="datepicker.toggle()" type="button"> <i class="bi-calendar-week"></i>{{formattedRange}}</button>
-  </div>
+    <button id="js-daterangepicker-predefined" class="btn btn-light btn-sm dropdown-toggle d-flex gap-2" (click)="datepicker.toggle()" type="button">
+      <i class="bi-calendar-week"></i>
+      <span>{{formattedRange}}</span>
+    </button>
 </form>

--- a/src/app/components/datepicker-range/datepicker-range.component.html
+++ b/src/app/components/datepicker-range/datepicker-range.component.html
@@ -1,8 +1,8 @@
 <form class="row row-cols-sm-auto">
-  <div class="col-12">
-    <div class="dp-hidden position-absolute">
-      <div class="input-group">
-        <input
+  <button class="btn btn-outline-secondary" (click)="datepicker.toggle()" type="button">{{ formattedRange }}</button>
+  <div class="dp-hidden position-absolute">
+    <div class="input-group">
+      <input
           name="datepicker"
           class="form-control"
           ngbDatepicker
@@ -29,29 +29,6 @@
         </ng-template>
       </div>
     </div>
-    <div class="input-group">
-      <input
-        #dpFromDate
-        class="form-control"
-        placeholder="yyyy-mm-dd"
-        name="dpFromDate"
-        [value]="formatter.format(fromDate)"
-        (input)="fromDate = validateInput(fromDate, dpFromDate.value)"
-      />
-      <button class="btn btn-outline-secondary bi bi-calendar3" (click)="datepicker.toggle()" type="button"></button>
-    </div>
-  </div>
-  <div class="col-12">
-    <div class="input-group">
-      <input
-        #dpToDate
-        class="form-control"
-        placeholder="yyyy-mm-dd"
-        name="dpToDate"
-        [value]="formatter.format(toDate)"
-        (input)="toDate = validateInput(toDate, dpToDate.value)"
-      />
-      <button class="btn btn-outline-secondary bi bi-calendar3" (click)="datepicker.toggle()" type="button"></button>
     </div>
   </div>
 </form>

--- a/src/app/components/datepicker-range/datepicker-range.component.scss
+++ b/src/app/components/datepicker-range/datepicker-range.component.scss
@@ -1,10 +1,8 @@
 .dp-hidden {
-  position: absolute;
-  left: -10000px;
-  top: auto;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
+  width: 0;
+  margin: 0;
+  border: none;
+  padding: 0;
 }
 .custom-day {
   text-align: center;

--- a/src/app/components/datepicker-range/datepicker-range.component.scss
+++ b/src/app/components/datepicker-range/datepicker-range.component.scss
@@ -1,8 +1,10 @@
 .dp-hidden {
-  width: 0;
-  margin: 0;
-  border: none;
-  padding: 0;
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
 }
 .custom-day {
   text-align: center;

--- a/src/app/components/datepicker-range/datepicker-range.component.scss
+++ b/src/app/components/datepicker-range/datepicker-range.component.scss
@@ -1,8 +1,14 @@
+form {
+  position: relative;
+}
+
 .dp-hidden {
   width: 0;
   margin: 0;
   border: none;
   padding: 0;
+  right: 0;
+  bottom: 0;
 }
 .custom-day {
   text-align: center;

--- a/src/app/components/datepicker-range/datepicker-range.component.ts
+++ b/src/app/components/datepicker-range/datepicker-range.component.ts
@@ -59,8 +59,13 @@ export class DatepickerRangeComponent extends BaseComponent implements OnInit {
     );
   }
 
-  validateInput(currentValue: NgbDate | null, input: string): NgbDate | null {
-    const parsed = this.formatter.parse(input);
-    return parsed && this.calendar.isValid(NgbDate.from(parsed)) ? NgbDate.from(parsed) : currentValue;
+  get formattedRange(): string {
+    if (this.fromDate && this.toDate) {
+      return `${this.formatter.format(this.fromDate)} - ${this.formatter.format(this.toDate)}`;
+    } else if (this.fromDate) {
+      return this.formatter.format(this.fromDate);
+    } else {
+      return 'Select Date Range';
+    }
   }
 }


### PR DESCRIPTION
- Removed the input fields for selecting start and end dates.
- Modified the component to display the selected date range directly in a button.
- The button now also toggles the datepicker visibility.
- Removed unused `validateInput` method from the component.