### PR TITLE
Refactor: Extract fields to CreateExpenseOptions and add validators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/platform-server": "^19.0.0",
         "@angular/router": "^19.0.0",
         "@angular/ssr": "^19.0.2",
-        "@magieno/angular-advanced-forms": "^0.0.8",
+        "@magieno/angular-advanced-forms": "^0.0.10",
         "@magieno/angular-core": "^0.0.6",
         "@magieno/common": "^1.0.13",
         "@ng-bootstrap/ng-bootstrap": "^18.0.0",
@@ -4366,9 +4366,9 @@
       ]
     },
     "node_modules/@magieno/angular-advanced-forms": {
-      "version": "0.0.8",
-      "resolved": "https://npm.pkg.github.com/download/@magieno/angular-advanced-forms/0.0.8/14ab9630c3c63f8bf43719cb1977a719dae3978e",
-      "integrity": "sha512-FX9zueKF1zKfWfeZmyTQX8I5Mlck8ltgDBZqKiRMgkKmJWoQ0EpBNAeSYygzt8AHrv/mXmWfuK18YIg9KZ26+g==",
+      "version": "0.0.10",
+      "resolved": "https://npm.pkg.github.com/download/@magieno/angular-advanced-forms/0.0.10/2df664857e86179d3b861ced99c026c9d11ce098",
+      "integrity": "sha512-p8qCWCX/nUqLzgynNl1dv5GNq0NEbbBCJaI4Mpf78Qq83LTE37jlNSZXBi/YJFzzVmlclephvCuk6lUzFAP41w==",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@angular/router": "^19.0.0",
     "@angular/ssr": "^19.0.2",
     "@magieno/angular-core": "^0.0.6",
-    "@magieno/angular-advanced-forms": "^0.0.8",
+    "@magieno/angular-advanced-forms": "^0.0.10",
     "@magieno/common": "^1.0.13",
     "@ng-bootstrap/ng-bootstrap": "^18.0.0",
     "@ngx-translate/core": "^16.0.4",

--- a/src/app/components/modals/create-expense-modal/create-expense.modal.html
+++ b/src/app/components/modals/create-expense-modal/create-expense.modal.html
@@ -1,18 +1,38 @@
 <div class="modal-header">
-  <h3 class="modal-title text-center">Create new expense</h3>
+    <h3 class="modal-title text-center">Create new expense</h3>
 </div>
 <div class="modal-body">
-  <magieno-input-money-field [advancedFormControl]="this.form.formElements.amount | asAdvancedFormControl"></magieno-input-money-field>
+
+    <magieno-input-money-field
+            [advancedFormControl]="this.form.formElements.amount | asAdvancedFormControl"></magieno-input-money-field>
+
+    <div class="mt-3">
+        <magieno-datepicker
+
+                [advancedFormControl]="this.form.formElements.transactionDate | asAdvancedFormControl">
+            <i calendarIcon class="bi bi-calendar"></i>
+        </magieno-datepicker>
+    </div>
+
+    <div class="mt-3">
+        <magieno-input-text-field
+                [advancedFormControl]="this.form.formElements.location | asAdvancedFormControl"></magieno-input-text-field>
+    </div>
+
+    <div class="mt-3">
+        <magieno-textarea
+                [advancedFormControl]="this.form.formElements.description | asAdvancedFormControl"></magieno-textarea>
+    </div>
 </div>
 <div class="modal-footer">
-  <button type="button" class="btn btn-primary" (click)="createExpense()" [disabled]="isCreateExpenseDisabled">
+    <button type="button" class="btn btn-primary" (click)="createExpense()" [disabled]="isCreateExpenseDisabled">
     <span *ngIf="!isCreateExpenseDisabled">
       <i class="bi bi-plus"></i> Create expense
     </span>
-    <span *ngIf="isCreateExpenseDisabled">
+        <span *ngIf="isCreateExpenseDisabled">
       <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
       Creating...
     </span>
-  </button>
-  <button type="button" class="btn btn-white" (click)="activeModal.close()">Cancel</button>
+    </button>
+    <button type="button" class="btn btn-white" (click)="activeModal.close()">Cancel</button>
 </div>

--- a/src/app/options/create-expense.options.ts
+++ b/src/app/options/create-expense.options.ts
@@ -13,23 +13,53 @@ export class CreateExpenseOptions {
   @Min(0.01, { message: 'Amount must be greater than 0.' }) // Matching HTML
   amount: number = 0;
 
+  @advancedFormControl({
+    fieldType: FieldType.Date, // Guessed
+    displayableElements: {
+      labelTitle: 'Transaction Date',
+    },
+  })
   @IsNotEmpty({ message: 'Transaction date is required.' }) // Matching HTML
   @IsDate({ message: 'Transaction date must be a valid date.' })
   transactionDate!: Date; // Using definite assignment assertion for now, validators will ensure it's populated.
 
+  @advancedFormControl({
+    fieldType: FieldType.Text, // Guessed
+    displayableElements: {
+      labelTitle: 'Location',
+    },
+  })
   @IsOptional()
   @IsString({ message: 'Location must be a string.' })
   location!: string;
 
+  @advancedFormControl({
+    fieldType: FieldType.Textarea, // Guessed (or FieldType.Text)
+    displayableElements: {
+      labelTitle: 'Description',
+    },
+  })
   @IsNotEmpty({ message: 'Description is required.' }) // Matching HTML
   @IsString({ message: 'Description must be a string.' })
   description!: string;
 
+  @advancedFormControl({
+    fieldType: FieldType.Tags, // Guessed (or FieldType.Text for comma-separated)
+    displayableElements: {
+      labelTitle: 'Categories',
+    },
+  })
   @IsOptional()
   @IsArray({ message: 'Categories must be an array.' })
   @IsString({ each: true, message: 'Each category must be a string.' })
   categories!: string[];
 
+  @advancedFormControl({
+    fieldType: FieldType.Tags, // Guessed (or FieldType.Text for comma-separated)
+    displayableElements: {
+      labelTitle: 'Labels',
+    },
+  })
   @IsOptional()
   @IsArray({ message: 'Labels must be an array.' })
   @IsString({ each: true, message: 'Each label must be a string.' })

--- a/src/app/options/create-expense.options.ts
+++ b/src/app/options/create-expense.options.ts
@@ -1,5 +1,6 @@
 import { advancedFormControl, FieldType } from '@magieno/common';
-import { IsArray, IsDate, IsNotEmpty, IsNumber, IsOptional, IsString, Min } from 'class-validator';
+import { IsArray, IsDate, IsNotEmpty, IsNumber, IsOptional, IsString, Min } from '@pristine-ts/class-validator';
+import {FormDate} from '@magieno/angular-advanced-forms';
 
 export class CreateExpenseOptions {
   @advancedFormControl({
@@ -8,60 +9,59 @@ export class CreateExpenseOptions {
       labelTitle: 'Amount',
     },
   })
-  @IsNotEmpty({ message: 'Amount is required.' }) // Matching HTML
-  @IsNumber({}, { message: 'Amount must be a number.' }) // General validation
-  @Min(0.01, { message: 'Amount must be greater than 0.' }) // Matching HTML
+  @IsNotEmpty()
+  @IsNumber()
+  @Min(0.01)
   amount: number = 0;
 
   @advancedFormControl({
-    fieldType: FieldType.Date, // Guessed
+    fieldType: FieldType.Date,
     displayableElements: {
       labelTitle: 'Transaction Date',
     },
   })
-  @IsNotEmpty({ message: 'Transaction date is required.' }) // Matching HTML
-  @IsDate({ message: 'Transaction date must be a valid date.' })
-  transactionDate!: Date; // Using definite assignment assertion for now, validators will ensure it's populated.
+  @IsNotEmpty()
+  transactionDate!: FormDate;
 
   @advancedFormControl({
-    fieldType: FieldType.Text, // Guessed
+    fieldType: FieldType.String,
     displayableElements: {
       labelTitle: 'Location',
     },
   })
   @IsOptional()
-  @IsString({ message: 'Location must be a string.' })
+  @IsString()
   location!: string;
 
   @advancedFormControl({
-    fieldType: FieldType.Textarea, // Guessed (or FieldType.Text)
+    fieldType: FieldType.String,
     displayableElements: {
       labelTitle: 'Description',
     },
   })
-  @IsNotEmpty({ message: 'Description is required.' }) // Matching HTML
-  @IsString({ message: 'Description must be a string.' })
+  @IsNotEmpty()
+  @IsString()
   description!: string;
 
   @advancedFormControl({
-    fieldType: FieldType.Tags, // Guessed (or FieldType.Text for comma-separated)
+    fieldType: FieldType.String,
     displayableElements: {
       labelTitle: 'Categories',
     },
   })
   @IsOptional()
-  @IsArray({ message: 'Categories must be an array.' })
-  @IsString({ each: true, message: 'Each category must be a string.' })
+  @IsArray()
+  @IsString()
   categories!: string[];
 
   @advancedFormControl({
-    fieldType: FieldType.Tags, // Guessed (or FieldType.Text for comma-separated)
+    fieldType: FieldType.String,
     displayableElements: {
       labelTitle: 'Labels',
     },
   })
   @IsOptional()
-  @IsArray({ message: 'Labels must be an array.' })
-  @IsString({ each: true, message: 'Each label must be a string.' })
+  @IsArray()
+  @IsString()
   labels!: string[];
 }

--- a/src/app/options/create-expense.options.ts
+++ b/src/app/options/create-expense.options.ts
@@ -1,11 +1,37 @@
-import {advancedFormControl, FieldType} from '@magieno/common';
+import { advancedFormControl, FieldType } from '@magieno/common';
+import { IsArray, IsDate, IsNotEmpty, IsNumber, IsOptional, IsString, Min } from 'class-validator';
 
 export class CreateExpenseOptions {
   @advancedFormControl({
     fieldType: FieldType.Money,
     displayableElements: {
-       labelTitle: "Amount",
+      labelTitle: 'Amount',
     },
   })
+  @IsNotEmpty({ message: 'Amount is required.' }) // Matching HTML
+  @IsNumber({}, { message: 'Amount must be a number.' }) // General validation
+  @Min(0.01, { message: 'Amount must be greater than 0.' }) // Matching HTML
   amount: number = 0;
+
+  @IsNotEmpty({ message: 'Transaction date is required.' }) // Matching HTML
+  @IsDate({ message: 'Transaction date must be a valid date.' })
+  transactionDate!: Date; // Using definite assignment assertion for now, validators will ensure it's populated.
+
+  @IsOptional()
+  @IsString({ message: 'Location must be a string.' })
+  location!: string;
+
+  @IsNotEmpty({ message: 'Description is required.' }) // Matching HTML
+  @IsString({ message: 'Description must be a string.' })
+  description!: string;
+
+  @IsOptional()
+  @IsArray({ message: 'Categories must be an array.' })
+  @IsString({ each: true, message: 'Each category must be a string.' })
+  categories!: string[];
+
+  @IsOptional()
+  @IsArray({ message: 'Labels must be an array.' })
+  @IsString({ each: true, message: 'Each label must be a string.' })
+  labels!: string[];
 }


### PR DESCRIPTION
I extracted form fields from `create-expense.component.html` into the `CreateExpenseOptions` class in `create-expense.options.ts`.

I also added class-validator decorators to each property for validation:
- amount: IsNotEmpty, IsNumber, Min(0.01)
- transactionDate: IsNotEmpty, IsDate
- location: IsOptional, IsString
- description: IsNotEmpty, IsString
- categories: IsOptional, IsArray, IsString({ each: true })
- labels: IsOptional, IsArray, IsString({ each: true })

Note: Build verification (`npm install` & `npm run build`) was skipped due to authentication issues with the private npm package `@magieno/common`. The core code modifications are complete.