### PR TITLE
feat: Add CsvProcessorService

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -30,6 +30,7 @@ import {CategoriesProvider} from './providers/categories.provider';
 import {LabelsProvider} from './providers/labels.provider';
 import {MagienoDragAndDropComponent} from '@magieno/angular-drag-and-drop';
 import {ImportStatementPage} from './pages/import-statement/import-statement.page';
+import { CsvProcessorService } from './services/csv.processor';
 
 @NgModule({
   declarations: [
@@ -91,6 +92,9 @@ import {ImportStatementPage} from './pages/import-statement/import-statement.pag
 
     // Stores,
     ToastStore,
+
+    // Services
+    CsvProcessorService,
   ],
   bootstrap: [RootComponent]
 })

--- a/src/app/services/csv.processor.ts
+++ b/src/app/services/csv.processor.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CsvProcessorService {
+
+  constructor() { }
+
+  processCsv(csvData: string): Record<string, string>[] {
+    if (!csvData) {
+      return [];
+    }
+
+    const lines = csvData.trim().split('\n');
+    if (lines.length < 1) {
+      return [];
+    }
+
+    const headers = lines[0].split(',').map(header => header.trim());
+    const records: Record<string, string>[] = [];
+
+    for (let i = 1; i < lines.length; i++) {
+      const values = lines[i].split(',').map(value => value.trim());
+      if (values.length === headers.length) {
+        const record: Record<string, string> = {};
+        headers.forEach((header, index) => {
+          record[header] = values[index];
+        });
+        records.push(record);
+      }
+    }
+    return records;
+  }
+}


### PR DESCRIPTION
Adds a new CsvProcessorService to parse CSV data.

This service includes a `processCsv` method that takes a CSV string, treats the first line as headers, and returns an array of objects representing the CSV rows.

The service has been registered in AppModule.

Skipped `npm run build` in the CI environment due to authentication issues with a private package, following your instructions to assume dependencies are present.