### PR TITLE
feat: Create StatementImporter and use in ImportStatementPage

### DIFF
--- a/src/app/importers/statement.importer.ts
+++ b/src/app/importers/statement.importer.ts
@@ -1,0 +1,16 @@
+import { CreateExpenseOptions } from '../options/create-expense.options';
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class StatementImporter {
+  constructor() {}
+
+  async process(file: File): Promise<CreateExpenseOptions[]> {
+    // For now, return a promise that resolves to an empty array.
+    // Add a console.log to show the file name for now.
+    console.log('Processing file in StatementImporter:', file.name);
+    return Promise.resolve([]);
+  }
+}

--- a/src/app/pages/import-statement/import-statement.page.ts
+++ b/src/app/pages/import-statement/import-statement.page.ts
@@ -6,6 +6,7 @@ import {BasePageComponent} from '../../components/base/base-page.component';
 import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
 import {CreateExpenseModal} from '../../components/modals/create-expense-modal/create-expense.modal';
 import {ImportStatementStateEnum} from '../../enums/import-statement-state.enum';
+import { StatementImporter } from '../../importers/statement.importer';
 
 @Component({
   selector: 'app-import-statement',
@@ -23,6 +24,7 @@ export class ImportStatementPage extends BasePageComponent implements OnInit {
     protected readonly router: Router,
     protected readonly ngbModal: NgbModal,
     title: Title,
+    private readonly statementImporter: StatementImporter
   ) {
     super(document, title);
   }
@@ -43,6 +45,15 @@ export class ImportStatementPage extends BasePageComponent implements OnInit {
       const file = await fileSystemFileHandle.getFile()
 
       console.log("Yesh")
+
+      // TODO: Add checks for file type and error handling
+      this.statementImporter.process(file).then(expenseOptions => {
+        console.log('Imported expense options:', expenseOptions);
+        // TODO: Set state to processing and then to display results
+      }).catch(error => {
+        console.error('Error processing statement:', error);
+        // TODO: Set state to error
+      });
 
       // if (file.type.startsWith("audio")) {
       //   this.fileSystemFileHandle = fileSystemHandle as FileSystemFileHandle;


### PR DESCRIPTION
Introduces a new `StatementImporter` service responsible for processing statement files. The service is injectable and currently returns an empty array of CreateExpenseOptions.

Modifications:
- Created `src/app/importers/statement.importer.ts`:
  - Defined `StatementImporter` class.
  - Marked as `@Injectable({ providedIn: 'root' })`.
  - Constructor takes no arguments.
  - `process(file: File)` method returns `Promise<CreateExpenseOptions[]>`.
- Updated `src/app/pages/import-statement/import-statement.page.ts`:
  - Injected `StatementImporter` service via constructor.
  - Called `this.statementImporter.process(file)` in `onFileSystemHandlesDropped`.

Note: I couldn't fully verify the build because I encountered an authentication error while trying to install a private package. This prevented the Angular CLI from installing.