### PR TITLE
feat: Inject PDF and CSV importers into StatementImporter

### DIFF
--- a/src/app/importers/statement.importer.ts
+++ b/src/app/importers/statement.importer.ts
@@ -16,8 +16,7 @@ export class StatementImporter {
     console.log('Processing file in StatementImporter:', file.name);
 
     if (file.type === 'text/csv') {
-      const csvData = await file.text();
-      const records = this.csvProcessor.processCsv(csvData);
+      const records = await this.csvProcessor.processCsv(file); // Changed this line
       // TODO: Convert records to CreateExpenseOptions[]
       console.log('CSV records:', records);
       return Promise.resolve([]); // Placeholder

--- a/src/app/importers/statement.importer.ts
+++ b/src/app/importers/statement.importer.ts
@@ -1,16 +1,34 @@
 import { CreateExpenseOptions } from '../options/create-expense.options';
 import { Injectable } from '@angular/core';
+import { CsvProcessorService } from '../services/csv.processor';
+import { PdfProcessor } from '../services/pdf.processor';
 
 @Injectable({
   providedIn: 'root'
 })
 export class StatementImporter {
-  constructor() {}
+  constructor(
+    private csvProcessor: CsvProcessorService,
+    private pdfProcessor: PdfProcessor
+  ) {}
 
   async process(file: File): Promise<CreateExpenseOptions[]> {
-    // For now, return a promise that resolves to an empty array.
-    // Add a console.log to show the file name for now.
     console.log('Processing file in StatementImporter:', file.name);
-    return Promise.resolve([]);
+
+    if (file.type === 'text/csv') {
+      const csvData = await file.text();
+      const records = this.csvProcessor.processCsv(csvData);
+      // TODO: Convert records to CreateExpenseOptions[]
+      console.log('CSV records:', records);
+      return Promise.resolve([]); // Placeholder
+    } else if (file.type === 'application/pdf') {
+      const images = await this.pdfProcessor.convertToImages(file);
+      // TODO: Process images to extract expense data
+      console.log('PDF images:', images);
+      return Promise.resolve([]); // Placeholder
+    } else {
+      console.warn('Unsupported file type:', file.type);
+      return Promise.resolve([]);
+    }
   }
 }

--- a/src/app/services/csv.processor.ts
+++ b/src/app/services/csv.processor.ts
@@ -7,7 +7,12 @@ export class CsvProcessorService {
 
   constructor() { }
 
-  processCsv(csvData: string): Record<string, string>[] {
+  async processCsv(file: File): Promise<Record<string, string>[]> {
+    if (!file) {
+      return [];
+    }
+
+    const csvData = await file.text();
     if (!csvData) {
       return [];
     }


### PR DESCRIPTION
I've injected CsvProcessorService and PdfProcessor into StatementImporter to enable processing of CSV and PDF files.

The `process` method in StatementImporter now checks the file type and uses the appropriate service to handle the file.