### PR TITLE
feat: Add image processor for bank statements and receipts

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -34,6 +34,8 @@ import { CsvProcessorService } from './processors/csv.processor';
 
 // Import the PdfProcessor service
 import { PdfProcessor } from './processors/pdf.processor';
+// Import the ImageProcessorService
+import { ImageProcessorService } from './processors/image.processor';
 
 @NgModule({
   declarations: [
@@ -99,6 +101,7 @@ import { PdfProcessor } from './processors/pdf.processor';
 
     // Services
     CsvProcessorService,
+    ImageProcessorService, // Add ImageProcessorService here
   ],
   bootstrap: [RootComponent]
 })

--- a/src/app/importers/statement.importer.ts
+++ b/src/app/importers/statement.importer.ts
@@ -2,6 +2,7 @@ import { CreateExpenseOptions } from '../options/create-expense.options';
 import { Injectable } from '@angular/core';
 import { CsvProcessorService } from '../processors/csv.processor';
 import { PdfProcessor } from '../processors/pdf.processor';
+import { ImageProcessorService } from '../processors/image.processor'; // Import ImageProcessorService
 
 @Injectable({
   providedIn: 'root'
@@ -9,11 +10,12 @@ import { PdfProcessor } from '../processors/pdf.processor';
 export class StatementImporter {
   constructor(
     private csvProcessor: CsvProcessorService,
-    private pdfProcessor: PdfProcessor
+    private pdfProcessor: PdfProcessor,
+    private imageProcessor: ImageProcessorService // Inject ImageProcessorService
   ) {}
 
   async process(file: File): Promise<CreateExpenseOptions[]> {
-    console.log('Processing file in StatementImporter:', file.name);
+    console.log('Processing file in StatementImporter:', file.name, file.type);
 
     // @ts-expect-error
     const session = await LanguageModel.create({
@@ -26,6 +28,44 @@ export class StatementImporter {
       ],
     });
 
+    const properties = Object.keys(new CreateExpenseOptions());
+    const extractionPrompt = `Transform this image into JSON by extracting all the expenses you find in this bank statement or receipt. Return an array of expenses containing these properties: ${properties.join(', ')}. If a property is not applicable, you can omit it or set its value to null. Only identify expenses.`;
+    const jsonSchema = {
+      responseConstraint: {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Expenses",
+        "description": "An array of expenses",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "title": "Expense",
+          "description": "A single expense record",
+          "required": [
+            "id",
+            "createdAt",
+            "transactionDate",
+            "amount",
+            "currency",
+            "location",
+            "description",
+            "categories",
+            "labels"
+          ],
+          "properties": {
+            "id": { "type": "string", "description": "Unique identifier for the expense", "format": "uuid" },
+            "createdAt": { "type": "string", "description": "The date and time the expense record was created", "format": "date-time" },
+            "transactionDate": { "type": "string", "description": "The date and time of the financial transaction", "format": "date-time" },
+            "amount": { "type": "number", "description": "The monetary value of the expense" },
+            "currency": { "type": "string", "description": "The currency of the amount" },
+            "location": { "type": "string", "description": "The location where the expense occurred" },
+            "description": { "type": "string", "description": "A brief description of the expense" },
+            "categories": { "type": "array", "description": "A list of categories for the expense", "items": { "type": "string" } },
+            "labels": { "type": "array", "description": "A list of labels for the expense", "items": { "type": "string" } }
+          }
+        }
+      }
+    };
+
     if (file.type === 'text/csv') {
       const records = await this.csvProcessor.processCsv(file);
       if (!records || records.length === 0) {
@@ -33,7 +73,7 @@ export class StatementImporter {
       }
 
       const headers = Object.keys(records[0]);
-      const properties = Object.keys(new CreateExpenseOptions());
+      // const properties = Object.keys(new CreateExpenseOptions()); // Already defined above
 
       const mappingPrompt = `Given the CSV headers: ${headers.join(', ')}, map them to the following properties: ${properties.join(', ')}. Provide the mapping as a JSON object where keys are CSV headers and values are property names.`;
 
@@ -44,7 +84,6 @@ export class StatementImporter {
         parsedMapping = JSON.parse(mappingConfig);
       } catch (error) {
         console.error('Error parsing mapping configuration:', error);
-        // Handle error or provide a default mapping
         return [];
       }
 
@@ -68,104 +107,15 @@ export class StatementImporter {
         return [];
       }
 
-      const properties = Object.keys(new CreateExpenseOptions());
-
       for (const image of images) {
-        // It's assumed that `image` here is a representation that can be used in a prompt,
-        // e.g., a URL or a base64 string. For this example, let's assume it's a URL or identifier.
-        // The actual image data/URL would need to be passed to the prompt if the LLM can process images.
-        // If not, the prompt needs to be very descriptive about what the user should do with the image they see elsewhere.
-        const extractionPrompt = `Transform this pdf into JSON by extracting all the expenses you find in this bank statement. Return an array of expenses containing these properties: ${properties.join(', ')}. If a property is not applicable, you can omit it or set its value to null. Only identify expenses.`;
-
         try {
           const extractedDataString = await session.prompt([
-            {
-              role: "user",
-              content: extractionPrompt,
-            },
-            {
-              role: "user",
-              content: [
-                {
-                  type: "image",
-                  value: image,
-                }
-              ]
-            }
-          ], {
-            responseConstraint: {
-              "$schema": "http://json-schema.org/draft-07/schema#",
-              "title": "Expenses",
-              "description": "An array of expenses",
-              "type": "array",
-              "items": {
-                "type": "object",
-                "title": "Expense",
-                "description": "A single expense record",
-                "required": [
-                  "id",
-                  "createdAt",
-                  "transactionDate",
-                  "amount",
-                  "currency",
-                  "location",
-                  "description",
-                  "categories",
-                  "labels"
-                ],
-                "properties": {
-                  "id": {
-                    "type": "string",
-                    "description": "Unique identifier for the expense",
-                    "format": "uuid"
-                  },
-                  "createdAt": {
-                    "type": "string",
-                    "description": "The date and time the expense record was created",
-                    "format": "date-time"
-                  },
-                  "transactionDate": {
-                    "type": "string",
-                    "description": "The date and time of the financial transaction",
-                    "format": "date-time"
-                  },
-                  "amount": {
-                    "type": "number",
-                    "description": "The monetary value of the expense"
-                  },
-                  "currency": {
-                    "type": "string",
-                    "description": "The currency of the amount"
-                  },
-                  "location": {
-                    "type": "string",
-                    "description": "The location where the expense occurred"
-                  },
-                  "description": {
-                    "type": "string",
-                    "description": "A brief description of the expense"
-                  },
-                  "categories": {
-                    "type": "array",
-                    "description": "A list of categories for the expense",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "labels": {
-                    "type": "array",
-                    "description": "A list of labels for the expense",
-                    "items": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          });
+            { role: "user", content: extractionPrompt },
+            { role: "user", content: [{ type: "image", value: image }] }
+          ], jsonSchema);
+
           if (extractedDataString) {
             const parsedData = JSON.parse(extractedDataString);
-            // We might get a single expense object or an array of them
             const itemsToProcess = Array.isArray(parsedData) ? parsedData : [parsedData];
 
             for (const item of itemsToProcess) {
@@ -179,9 +129,41 @@ export class StatementImporter {
             }
           }
         } catch (error) {
-          console.error('Error processing image extraction or parsing JSON:', error);
-          // Optionally, continue to the next image or handle the error appropriately
+          console.error('Error processing PDF image extraction or parsing JSON:', error);
         }
+      }
+      return allExpenseOptions;
+    } else if (file.type.startsWith('image/')) { // Handle image files
+      const imageBitmap = await this.imageProcessor.processImage(file);
+      const allExpenseOptions: CreateExpenseOptions[] = [];
+
+      if (!imageBitmap) {
+        console.log('No image bitmap processed from the file.');
+        return [];
+      }
+
+      try {
+        const extractedDataString = await session.prompt([
+          { role: "user", content: extractionPrompt },
+          { role: "user", content: [{ type: "image", value: imageBitmap }] }
+        ], jsonSchema);
+
+        if (extractedDataString) {
+          const parsedData = JSON.parse(extractedDataString);
+          const itemsToProcess = Array.isArray(parsedData) ? parsedData : [parsedData];
+
+          for (const item of itemsToProcess) {
+            const expenseOptions = new CreateExpenseOptions();
+            for (const property of properties) {
+              if (item.hasOwnProperty(property)) {
+                (expenseOptions as any)[property] = item[property];
+              }
+            }
+            allExpenseOptions.push(expenseOptions);
+          }
+        }
+      } catch (error) {
+        console.error('Error processing image extraction or parsing JSON:', error);
       }
       return allExpenseOptions;
     } else {

--- a/src/app/processors/image.processor.ts
+++ b/src/app/processors/image.processor.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ImageProcessorService {
+  constructor() {}
+
+  async processImage(file: File): Promise<ImageBitmap | null> {
+    if (!file.type.startsWith('image/')) {
+      console.error('File is not an image:', file.type);
+      return null;
+    }
+
+    try {
+      const imageBitmap = await createImageBitmap(file);
+      return imageBitmap;
+    } catch (error) {
+      console.error('Error processing image:', error);
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
I've implemented an ImageProcessorService to convert image files (PNG, JPEG, etc.) into ImageBitmap objects.

This service has been integrated into the StatementImporter to allow processing of image-based bank statements or receipts. The importer now uses a similar LLM-based data extraction approach for images as it does for pages extracted from PDF files.

I've refactored the StatementImporter to share common LLM prompting logic between PDF image handling and direct image file handling.

Note: I couldn't fully verify `npm install` and `npm run build` due to an authentication issue with a private GitHub package unrelated to these changes.