### PR TITLE
feat: Create ExpenseImportTableComponent

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -36,6 +36,7 @@ import { CsvProcessorService } from './processors/csv.processor';
 import { PdfProcessor } from './processors/pdf.processor';
 // Import the ImageProcessorService
 import { ImageProcessorService } from './processors/image.processor';
+import { ExpenseImportTable } from './components/expense-import-table/expense-import-table';
 
 @NgModule({
   declarations: [
@@ -60,6 +61,7 @@ import { ImageProcessorService } from './processors/image.processor';
 
     // Modals
     CreateExpenseModal,
+     ExpenseImportTable,
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/expense-import-table/expense-import-table.html
+++ b/src/app/components/expense-import-table/expense-import-table.html
@@ -1,0 +1,26 @@
+<table>
+  <thead>
+    <tr>
+      <th>Amount</th>
+      <th>Transaction Date</th>
+      <th>Location</th>
+      <th>Description</th>
+      <th>Categories</th>
+      <th>Labels</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr *ngFor="let expense of expenseOptions; let i = index">
+      <td><input type="number" [(ngModel)]="expense.amount" name="amount_{{i}}"></td>
+      <td><input type="date" [(ngModel)]="expense.transactionDate" name="transactionDate_{{i}}"></td>
+      <td><input type="text" [(ngModel)]="expense.location" name="location_{{i}}"></td>
+      <td><input type="text" [(ngModel)]="expense.description" name="description_{{i}}"></td>
+      <td><input type="text" [(ngModel)]="expense.categories" name="categories_{{i}}"></td>
+      <td><input type="text" [(ngModel)]="expense.labels" name="labels_{{i}}"></td>
+      <td><button (click)="deleteExpenseOption(i)">Delete</button></td>
+    </tr>
+  </tbody>
+</table>
+
+<button (click)="addExpenseOption()">Add New Expense</button>

--- a/src/app/components/expense-import-table/expense-import-table.spec.ts
+++ b/src/app/components/expense-import-table/expense-import-table.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ExpenseImportTable } from './expense-import-table';
+
+describe('ExpenseImportTable', () => {
+  let component: ExpenseImportTable;
+  let fixture: ComponentFixture<ExpenseImportTable>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ExpenseImportTable]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ExpenseImportTable);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/expense-import-table/expense-import-table.ts
+++ b/src/app/components/expense-import-table/expense-import-table.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { CreateExpenseOptions } from '../../../options/create-expense.options';
+import { CreateExpenseOptions } from '../../options/create-expense.options';
 
 @Component({
   selector: 'app-expense-import-table',

--- a/src/app/components/expense-import-table/expense-import-table.ts
+++ b/src/app/components/expense-import-table/expense-import-table.ts
@@ -1,0 +1,22 @@
+import { Component, Input } from '@angular/core';
+import { CreateExpenseOptions } from '../../../options/create-expense.options';
+
+@Component({
+  selector: 'app-expense-import-table',
+  standalone: false,
+  templateUrl: './expense-import-table.html',
+  styleUrl: './expense-import-table.scss'
+})
+export class ExpenseImportTable {
+  @Input() expenseOptions: CreateExpenseOptions[] = [];
+
+  addExpenseOption(): void {
+    this.expenseOptions.push(new CreateExpenseOptions());
+  }
+
+  deleteExpenseOption(index: number): void {
+    if (index >= 0 && index < this.expenseOptions.length) {
+      this.expenseOptions.splice(index, 1);
+    }
+  }
+}


### PR DESCRIPTION
Adds a new ExpenseImportTableComponent for managing an array of expense creation options.

Key features:
- Displays expense options in a table format.
- Each property of an expense option is an editable input field.
- Allows adding new expense rows.
- Allows deleting existing expense rows.

The component is not standalone and has been added to AppModule. The component is located at `src/app/components/expense-import-table/`.

Note: I could not fully verify the build due to an authentication error while attempting to download the private `@magieno/common` package during the installation of dependencies. The component code itself should be complete as per your requirements.