### PR TITLE
feat(statement-preview): Implement image pagination

### DIFF
--- a/src/app/components/statement-preview/statement-preview.component.html
+++ b/src/app/components/statement-preview/statement-preview.component.html
@@ -1,4 +1,5 @@
 <div *ngIf="previewData">
+  <!-- CSV Preview Section (no changes here) -->
   <div *ngIf="isCsvData && csvHeaders.length > 0" class="table-responsive">
     <h5>CSV Preview</h5>
     <table class="table table-striped table-bordered">
@@ -15,20 +16,34 @@
     </table>
   </div>
 
-  <!-- Changed to render ImageBitmaps on canvas -->
+  <!-- Image Preview Section - Modified for single canvas and pagination -->
   <div *ngIf="!isCsvData && imageBitmapsToRender.length > 0">
     <h5>Image Preview</h5>
-    <div *ngFor="let bitmap of imageBitmapsToRender; let i = index" class="image-preview-container">
+
+    <!-- Single Canvas for Image Display -->
+    <div class="image-preview-container">
       <canvas #previewCanvas class="preview-canvas" style="border: 1px solid #ccc; margin-bottom: 10px;"></canvas>
-      <!-- Width and height are set in drawImages method to 768x768 -->
+      <!-- Width and height are set in drawCurrentImageInternal method -->
+    </div>
+
+    <!-- Pagination Controls -->
+    <div *ngIf="totalPages > 1" class="pagination-controls" style="margin-top: 10px; text-align: center;">
+      <button class="btn btn-secondary btn-sm me-2" (click)="previousPage()" [disabled]="currentPageIndex === 0">
+        <i class="bi bi-arrow-left"></i> Previous
+      </button>
+      <span style="margin: 0 10px;">
+        Page {{ currentPageIndex + 1 }} of {{ totalPages }}
+      </span>
+      <button class="btn btn-secondary btn-sm ms-2" (click)="nextPage()" [disabled]="currentPageIndex >= totalPages - 1">
+        Next <i class="bi bi-arrow-right"></i>
+      </button>
     </div>
   </div>
 
-  <!-- Updated empty state check for images -->
+  <!-- Empty States (no changes here) -->
   <div *ngIf="showEmptyImageState">
      <p>No images to display for preview, or image data is empty.</p>
   </div>
-  <!-- More specific empty state for CSV -->
   <div *ngIf="isCsvData && csvHeaders.length === 0 && csvRows.length === 0 && previewData && !imageBitmapsToRender.length">
      <p>CSV file seems to be empty or has no headers.</p>
   </div>

--- a/src/app/components/statement-preview/statement-preview.component.ts
+++ b/src/app/components/statement-preview/statement-preview.component.ts
@@ -1,5 +1,5 @@
-import { Component, Input, OnChanges, SimpleChanges, ElementRef, ViewChildren, QueryList, AfterViewInit } from '@angular/core';
-import { PreviewData } from '../../importers/statement.importer'; // This now includes ImageBitmap types
+import { Component, Input, OnChanges, SimpleChanges, ElementRef, ViewChild, AfterViewInit } from '@angular/core'; // QueryList removed, ViewChild added
+import { PreviewData } from '../../importers/statement.importer';
 import { CsvPreviewData } from '../../processors/csv.processor';
 
 @Component({
@@ -16,29 +16,28 @@ export class StatementPreviewComponent implements OnChanges, AfterViewInit {
   csvRows: Record<string, string>[] = [];
   imageBitmapsToRender: ImageBitmap[] = [];
 
-  @ViewChildren('previewCanvas') previewCanvases!: QueryList<ElementRef<HTMLCanvasElement>>;
+  // Pagination properties
+  public currentPageIndex: number = 0;
+  public totalPages: number = 0;
+
+  @ViewChild('previewCanvas') previewCanvas!: ElementRef<HTMLCanvasElement>; // Changed to ViewChild for a single canvas
 
   private viewInitialized = false;
 
   public get showEmptyImageState(): boolean {
     return !this.isCsvData &&
            this.imageBitmapsToRender.length === 0 &&
-           this.previewData !== null && // Ensure previewData is not null
+           this.previewData !== null &&
            (this.previewData instanceof ImageBitmap || this.isImageBitmapArray(this.previewData));
   }
 
   constructor() {}
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['previewData']) { // Process if previewData input changes
+    if (changes['previewData']) {
       this.processPreviewData();
       if (this.viewInitialized && !this.isCsvData && this.imageBitmapsToRender.length > 0) {
-        // Ensure drawing happens after data is processed and view is ready
-        // Use a timeout to allow DOM to update with canvases from *ngFor
-        setTimeout(() => this.drawImages(), 0);
-      } else if (this.isCsvData || this.imageBitmapsToRender.length === 0) {
-        // If data is CSV or no images to render, ensure canvases are not attempted to be drawn
-        // (This can happen if previewData was previously images and now is CSV or null)
+        setTimeout(() => this.drawCurrentImage(), 0);
       }
     }
   }
@@ -46,8 +45,7 @@ export class StatementPreviewComponent implements OnChanges, AfterViewInit {
   ngAfterViewInit(): void {
     this.viewInitialized = true;
     if (!this.isCsvData && this.imageBitmapsToRender.length > 0) {
-      // Initial draw if data was already present
-      setTimeout(() => this.drawImages(), 0);
+      setTimeout(() => this.drawCurrentImage(), 0);
     }
   }
 
@@ -61,25 +59,23 @@ export class StatementPreviewComponent implements OnChanges, AfterViewInit {
     } else if (Array.isArray(this.previewData) && this.previewData.length > 0 && this.previewData[0] instanceof ImageBitmap) {
       this.isCsvData = false;
       this.imageBitmapsToRender = this.previewData as ImageBitmap[];
-    } else if (this.isCsvPreviewData(this.previewData)) { // This check must be after ImageBitmap checks
+    } else if (this.isCsvPreviewData(this.previewData)) {
       this.isCsvData = true;
-      this.csvHeaders = (this.previewData as CsvPreviewData).headers; // Type assertion
-      this.csvRows = (this.previewData as CsvPreviewData).rows;     // Type assertion
+      this.csvHeaders = (this.previewData as CsvPreviewData).headers;
+      this.csvRows = (this.previewData as CsvPreviewData).rows;
     }
-    // Note: If previewData is an empty array, or not matching any type,
-    // imageBitmapsToRender will be empty and isCsvData will be false due to resetData.
+
+    this.totalPages = this.imageBitmapsToRender.length; // Calculate total pages
+    this.currentPageIndex = 0; // Reset current page
   }
 
   private isCsvPreviewData(data: PreviewData): data is CsvPreviewData {
-    // Ensure it's not an ImageBitmap or array of ImageBitmap before checking CsvPreviewData structure
     if (data instanceof ImageBitmap || (Array.isArray(data) && data.length > 0 && data[0] instanceof ImageBitmap)) {
         return false;
     }
-    // Check if it's not null and is an object (excluding arrays, which are handled above for ImageBitmap[])
     if (data === null || typeof data !== 'object' || Array.isArray(data)) {
         return false;
     }
-    // Now, safely check for CsvPreviewData properties
     return 'headers' in data && 'rows' in data;
   }
 
@@ -88,48 +84,73 @@ export class StatementPreviewComponent implements OnChanges, AfterViewInit {
     this.csvHeaders = [];
     this.csvRows = [];
     this.imageBitmapsToRender = [];
+    this.totalPages = 0; // Reset total pages
+    this.currentPageIndex = 0; // Reset current page
   }
 
-  isImageBitmapArray(data: any): boolean { // Made public by removing 'private'
+  isImageBitmapArray(data: any): boolean {
     if (Array.isArray(data) && data.length > 0) {
       return data.every(item => item instanceof ImageBitmap);
     }
     return false;
   }
 
-  private drawImages(): void {
-    if (!this.previewCanvases || this.previewCanvases.length !== this.imageBitmapsToRender.length) {
-      console.warn('Preview canvases not ready or mismatch with image data. Attempting redraw shortly...');
-      // This uses a timeout to wait for the QueryList to update after *ngFor has rendered the canvases.
+  // Method to draw the current image
+  private drawCurrentImage(): void {
+    if (!this.previewCanvas || !this.previewCanvas.nativeElement) {
+      console.warn('Preview canvas not ready. Attempting redraw shortly...');
       setTimeout(() => {
-        if (this.viewInitialized && !this.isCsvData && this.imageBitmapsToRender.length > 0 &&
-            this.previewCanvases.length === this.imageBitmapsToRender.length) {
-            this.drawImagesInternal();
-        } else if (this.previewCanvases.length !== this.imageBitmapsToRender.length) {
-            console.error('Canvas and image data mismatch even after delay. Cannot draw images.');
+        if (this.viewInitialized && this.previewCanvas && this.previewCanvas.nativeElement) {
+            this.drawCurrentImageInternal();
+        } else {
+            console.error('Canvas not ready even after delay. Cannot draw image.');
         }
-      }, 50); // A small delay, adjust if needed
+      }, 50);
       return;
     }
-    this.drawImagesInternal();
+    this.drawCurrentImageInternal();
   }
 
-  private drawImagesInternal(): void {
-    if (!this.previewCanvases) return; // Guard against undefined QueryList
-
-    this.previewCanvases.forEach((canvasRef, index) => {
-      const bitmap = this.imageBitmapsToRender[index];
-      if (bitmap && canvasRef && canvasRef.nativeElement) { // Added null check for nativeElement
-        const canvas = canvasRef.nativeElement;
-        canvas.width = 768;
-        canvas.height = 768;
-        const ctx = canvas.getContext('2d');
-        if (ctx) {
-          ctx.drawImage(bitmap, 0, 0, 768, 768);
-        } else {
-          console.error('Failed to get 2D context for canvas at index ' + index);
+  private drawCurrentImageInternal(): void {
+    if (!this.previewCanvas || !this.previewCanvas.nativeElement || this.imageBitmapsToRender.length === 0) {
+        // Clear canvas if no images or canvas not ready
+        if (this.previewCanvas && this.previewCanvas.nativeElement) {
+            const canvas = this.previewCanvas.nativeElement;
+            const ctx = canvas.getContext('2d');
+            if (ctx) {
+                ctx.clearRect(0, 0, canvas.width, canvas.height);
+            }
         }
+        return;
+    }
+
+    const bitmap = this.imageBitmapsToRender[this.currentPageIndex];
+    if (bitmap) {
+      const canvas = this.previewCanvas.nativeElement;
+      canvas.width = 768; // Consider making these configurable or dynamic
+      canvas.height = 768;
+      const ctx = canvas.getContext('2d');
+      if (ctx) {
+        ctx.clearRect(0, 0, canvas.width, canvas.height); // Clear before drawing
+        ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+      } else {
+        console.error('Failed to get 2D context for canvas.');
       }
-    });
+    }
+  }
+
+  // Navigation methods
+  public nextPage(): void {
+    if (this.currentPageIndex < this.totalPages - 1) {
+      this.currentPageIndex++;
+      this.drawCurrentImage();
+    }
+  }
+
+  public previousPage(): void {
+    if (this.currentPageIndex > 0) {
+      this.currentPageIndex--;
+      this.drawCurrentImage();
+    }
   }
 }


### PR DESCRIPTION
I've implemented pagination for multiple images in the statement preview component.

Key changes:
- I modified StatementPreviewComponent to manage a list of images with a current page index.
- I added 'Next' and 'Previous' buttons to navigate through images.
- The component now displays the current page number and total number of pages.
- I updated the component to use a single canvas element to display the current image, which should improve performance and simplify the DOM structure.
- I ensured the HTML template reflects these changes with pagination controls and a single canvas.
- I verified that StatementPreviewComponent remains correctly declared in app.module.ts.

Note: I encountered an authentication error (401 Unauthorized) when trying to install a private package from npm.pkg.github.com. This prevented Angular CLI and other dependencies from being installed, so I couldn't complete the build verification. The code changes I made are independent of this issue, but I wasn't able to fully test them in a build environment.