### PR TITLE
Refactor: Unify import processing UI state

### DIFF
--- a/src/app/pages/import-statement/import-statement.page.html
+++ b/src/app/pages/import-statement/import-statement.page.html
@@ -10,18 +10,8 @@
   {{ processingError }}
 </div>
 
-<!-- Global Preview Loading Indicator -->
-<div *ngIf="isPreviewLoading" class="row justify-content-center text-center py-5">
-  <div class="col-auto">
-    <div class="spinner-border text-primary" role="status" style="width: 3rem; height: 3rem;">
-      <span class="visually-hidden">Generating Preview...</span>
-    </div>
-    <p class="mt-3 fs-5">Generating Preview...</p>
-  </div>
-</div>
-
-<!-- State-dependent content, only shown if not loading preview -->
-<div *ngIf="!isPreviewLoading">
+<!-- State-dependent content -->
+<div>
   @if(state === ImportStatementStateEnum.WaitingForStatement) {
     <div class="row">
       <div class="col-12">
@@ -49,7 +39,7 @@
           <button class="btn btn-lg btn-primary me-3" (click)="confirmAndProcessStatement()">
             <i class="bi bi-check-circle-fill me-2"></i>Confirm and Process Statement
           </button>
-          <button class="btn btn-lg btn-outline-secondary" (click)="state = ImportStatementStateEnum.WaitingForStatement; previewData = null; currentFile = null; processingError = null; isPreviewLoading = false;"> <!-- Ensure isPreviewLoading is reset -->
+          <button class="btn btn-lg btn-outline-secondary" (click)="state = ImportStatementStateEnum.WaitingForStatement; previewData = null; currentFile = null; processingError = null;">
             <i class="bi bi-x-circle me-2"></i>Cancel
           </button>
         </div>
@@ -59,9 +49,9 @@
     <div class="row justify-content-center text-center py-5">
       <div class="col-auto">
         <div class="spinner-border text-success" role="status" style="width: 3rem; height: 3rem;">
-          <span class="visually-hidden">Processing Statement...</span>
+          <span class="visually-hidden">Processing file...</span>
         </div>
-        <p class="mt-3 fs-5">Processing Statement with AI... Please wait.</p>
+        <p class="mt-3 fs-5">Processing file... Please wait.</p>
       </div>
     </div>
   } @else if (state === ImportStatementStateEnum.StatementProcessed) {
@@ -71,7 +61,7 @@
         <h4 class="mt-3">Statement Processed!</h4>
         <p class="fs-5">Expenses found have been processed.</p>
         <p class="text-muted">(Further steps like review or listing would follow here)</p>
-        <button class="btn btn-lg btn-info mt-3" (click)="state = ImportStatementStateEnum.WaitingForStatement; previewData = null; currentFile = null; processingError = null; isPreviewLoading = false;"> <!-- Ensure isPreviewLoading is reset -->
+        <button class="btn btn-lg btn-info mt-3" (click)="state = ImportStatementStateEnum.WaitingForStatement; previewData = null; currentFile = null; processingError = null;">
           <i class="bi bi-file-earmark-arrow-up-fill me-2"></i>Import Another Statement
         </button>
       </div>
@@ -82,7 +72,7 @@
             <i class="bi bi-card-list text-primary" style="font-size: 4rem;"></i>
             <h4 class="mt-3">Review Expenses</h4>
             <p class="fs-5">This state will show the expenses found for your review and approval.</p>
-            <button class="btn btn-lg btn-secondary mt-3" (click)="state = ImportStatementStateEnum.WaitingForStatement; previewData = null; currentFile = null; processingError = null; isPreviewLoading = false;"> <!-- Ensure isPreviewLoading is reset -->
+            <button class="btn btn-lg btn-secondary mt-3" (click)="state = ImportStatementStateEnum.WaitingForStatement; previewData = null; currentFile = null; processingError = null;">
               <i class="bi bi-arrow-left-circle me-2"></i>Start Over
             </button>
           </div>
@@ -98,8 +88,8 @@
     ImportStatementStateEnum.ReviewExpensesFound
   ].includes(state)" class="alert alert-warning my-3">
     <p><i class="bi bi-exclamation-triangle-fill me-2"></i>Unhandled application state. An unexpected error might have occurred.</p>
-    <button class="btn btn-secondary btn-sm" (click)="state = ImportStatementStateEnum.WaitingForStatement; previewData = null; currentFile = null; processingError = null; isPreviewLoading = false;"> <!-- Ensure isPreviewLoading is reset -->
+    <button class="btn btn-secondary btn-sm" (click)="state = ImportStatementStateEnum.WaitingForStatement; previewData = null; currentFile = null; processingError = null;">
       <i class="bi bi-house-door me-2"></i>Reset to Start
     </button>
   </div>
-</div> <!-- End of *ngIf="!isPreviewLoading" -->
+</div>

--- a/src/app/pages/import-statement/import-statement.page.ts
+++ b/src/app/pages/import-statement/import-statement.page.ts
@@ -19,7 +19,6 @@ export class ImportStatementPage extends BasePageComponent implements OnInit {
   previewData: PreviewData | null = null;
   currentFile: File | null = null;
   processingError: string | null = null;
-  isPreviewLoading: boolean = false; // Added isPreviewLoading
 
   constructor(
     @Inject(DOCUMENT) document: Document,
@@ -42,7 +41,6 @@ export class ImportStatementPage extends BasePageComponent implements OnInit {
     this.previewData = null;
     this.currentFile = null;
     this.state = ImportStatementStateEnum.WaitingForStatement;
-    this.isPreviewLoading = false; // Reset
 
     if (!fileSystemHandles || fileSystemHandles.length === 0) {
         this.processingError = "No file provided.";
@@ -64,11 +62,10 @@ export class ImportStatementPage extends BasePageComponent implements OnInit {
     const file = await fileSystemFileHandle.getFile();
     this.currentFile = file;
 
-    this.isPreviewLoading = true; // Indicate loading of preview
+    this.state = ImportStatementStateEnum.ProcessingStatement; // Set state to ProcessingStatement
 
     try {
       this.previewData = await this.statementImporter.extractPreviewData(file);
-      this.isPreviewLoading = false; // Preview loading finished
 
       if (this.previewData === null && file.type.startsWith('image/')) {
          this.processingError = "Could not generate preview for this image file. It might be corrupted or an unsupported image format.";
@@ -78,14 +75,13 @@ export class ImportStatementPage extends BasePageComponent implements OnInit {
             this.processingError = "CSV file appears to be empty or does not contain headers.";
             this.state = ImportStatementStateEnum.WaitingForStatement;
         } else {
-            this.state = ImportStatementStateEnum.PREVIEWING_STATEMENT; // UPDATED STATE
+            this.state = ImportStatementStateEnum.PREVIEWING_STATEMENT;
         }
       } else {
         this.processingError = "Could not generate preview for this file type or the file is empty/corrupted.";
         this.state = ImportStatementStateEnum.WaitingForStatement;
       }
     } catch (error) {
-      this.isPreviewLoading = false; // Preview loading finished (with error)
       console.error('Error extracting preview data:', error);
       this.processingError = "Error generating file preview. Please try another file.";
       this.state = ImportStatementStateEnum.WaitingForStatement;
@@ -95,7 +91,7 @@ export class ImportStatementPage extends BasePageComponent implements OnInit {
   async confirmAndProcessStatement() {
     if (!this.currentFile) {
       this.processingError = "No file selected for processing.";
-      this.state = this.previewData ? ImportStatementStateEnum.PREVIEWING_STATEMENT : ImportStatementStateEnum.WaitingForStatement; // UPDATED STATE
+      this.state = this.previewData ? ImportStatementStateEnum.PREVIEWING_STATEMENT : ImportStatementStateEnum.WaitingForStatement;
       return;
     }
 


### PR DESCRIPTION
- Removed `isPreviewLoading` from `ImportStatementPage`.
- Unified loading indication under the `ProcessingStatement` state for both preview generation and main statement processing.
- Updated HTML template to reflect these changes and use a generic "Processing file..." message.

Skipped `npm install` and `npm run build` due to a GitHub Packages authentication error in the environment.