### PR TITLE
feat: Add DateRangeUtils with getPreviousRange method

### DIFF
--- a/srv/app/utils/date-range.utils.ts
+++ b/srv/app/utils/date-range.utils.ts
@@ -1,0 +1,18 @@
+import { DateRangeInterface } from '../../interfaces/date-range.interface';
+
+export class DateRangeUtils {
+  public static getPreviousRange(dateRange: DateRangeInterface): DateRangeInterface {
+    const fromDate = new Date(dateRange.fromDate);
+    const toDate = new Date(dateRange.toDate);
+
+    const duration = toDate.getTime() - fromDate.getTime();
+
+    const previousToDate = new Date(fromDate.getTime() - 1); // Subtract 1 millisecond to get the day before the current range starts
+    const previousFromDate = new Date(previousToDate.getTime() - duration);
+
+    return {
+      fromDate: previousFromDate,
+      toDate: previousToDate,
+    };
+  }
+}


### PR DESCRIPTION
This commit introduces a new utility class, DateRangeUtils, within srv/app/utils.

The class includes a static method getPreviousRange(dateRange: DateRangeInterface) which calculates and returns the date range immediately preceding the input range, maintaining the same duration.

Unit tests were not added for this utility as per user request during development, but are recommended for future iterations.